### PR TITLE
Add google auth package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "accountable-app",
       "version": "1.0.0",
       "dependencies": {
+        "@react-native-google-signin/google-signin": "^11.0.1",
         "expo": "~50.0.14",
         "expo-status-bar": "~1.11.1",
         "react": "18.2.0",
@@ -5456,6 +5457,21 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
+    "node_modules/@react-native-google-signin/google-signin": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@react-native-google-signin/google-signin/-/google-signin-11.0.1.tgz",
+      "integrity": "sha512-ZRSEd1ME31XZ+azS3Qe6TRb8NRicGmtRdD1vT4Tz2birnlTfNfRgy4qLrEKNZyMUTodA6+J2UvA2JWwT8ZQ/dw==",
+      "peerDependencies": {
+        "expo": ">=47.0.0",
+        "react": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@react-native/assets-registry": {
       "version": "0.73.1",
       "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.73.1.tgz",
@@ -7654,9 +7670,9 @@
       }
     },
     "node_modules/expo": {
-      "version": "50.0.14",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-50.0.14.tgz",
-      "integrity": "sha512-yLPdxCMVAbmeEIpzzyAuJ79wvr6ToDDtQmuLDMAgWtjqP8x3CGddXxUe07PpKEQgzwJabdHvCLP5Bv94wMFIjQ==",
+      "version": "50.0.15",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-50.0.15.tgz",
+      "integrity": "sha512-tsyRmMHjA8lPlM7AsqH1smSH8hzmn1+x/vsP+xgbKYJTGtYccdY/wsm6P84VJWeK5peWSVqrWNos+YuPqXKLSQ==",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "0.17.8",
@@ -7670,7 +7686,7 @@
         "expo-font": "~11.10.3",
         "expo-keep-awake": "~12.8.2",
         "expo-modules-autolinking": "1.10.3",
-        "expo-modules-core": "1.11.12",
+        "expo-modules-core": "1.11.13",
         "fbemitter": "^3.0.0",
         "whatwg-url-without-unicode": "8.0.0-3"
       },
@@ -7843,9 +7859,9 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "1.11.12",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-1.11.12.tgz",
-      "integrity": "sha512-/e8g4kis0pFLer7C0PLyx98AfmztIM6gU9jLkYnB1pU9JAfQf904XEi3bmszO7uoteBQwSL6FLp1m3TePKhDaA==",
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-1.11.13.tgz",
+      "integrity": "sha512-2H5qrGUvmLzmJNPDOnovH1Pfk5H/S/V0BifBmOQyDc9aUh9LaDwkqnChZGIXv8ZHDW8JRlUW0QqyWxTggkbw1A==",
       "dependencies": {
         "invariant": "^2.2.4"
       }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@react-native-google-signin/google-signin": "^11.0.1",
     "expo": "~50.0.14",
     "expo-status-bar": "~1.11.1",
     "react": "18.2.0",


### PR DESCRIPTION
Bumps #2: Google login.

Here is how to set this up.
1. Register a domain name and some cloud hosting.
1. Go to Google Cloud Console and navigate to "API and Services": https://console.cloud.google.com/apis/dashboard
1. Set up an OAuth Consent Screen
1. Then go to the Credentials section and add some credentials
1. Select "Create OAuth client ID"
1. It's easier to create this for a web application, which is why I recommend doing that first. If you want to creat it for Andriod, you will need to set up this Andriod app for deployment.
1. Once the credentials are generated, add them to this app.

More detailed instructions here: https://react-native-google-signin.github.io/docs/setting-up/expo#expo-and-firebase